### PR TITLE
Feature/multiple patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ You can run Cchecker from the command line with the following syntax:
 ./ccheck <pattern> <root> <file_extension> <flags>
 ```
 
-- `<pattern>`: The keyword or phrase you want to check for.
+- `<pattern>`: The keyword or phrase you want to check for, can be multiple words, separated by a comma. Prefix with `re:` to treat it as a regex pattern.
 - `<root>`: The root directory to start the check.
-- `<file_extension>`: The file extension to filter files (use "*" for all files).
+- `<file_extension>`: The file extension to filter files (use "*" for all files, separate by a comma for multiple file extentions).
 - `<flags>`: Optional flags for additional functionality. Currently only supports -i for case-insensitive search and -o=<file_path> for saving the result to a file.
 
 Example:
 ```bash
-./ccheck "TODO" ~/Coding ".go" -i
+./ccheck "TODO, re:^func" ~/Coding ".go, .rs" -i -o=output.txt
 ```
 or
 ```bash

--- a/handling/args.go
+++ b/handling/args.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func ParseArgs() (pattern []*regexp.Regexp, root string, extList []string, outputFile *os.File) {
+func ParseArgs() (patterns []*regexp.Regexp, root string, extList []string, outputFile *os.File) {
 	if len(os.Args) < 4 {
 		fmt.Println(PrintError("not enough arguments", "at least 3 arguments required"))
 		fmt.Println("Usage: go run main.go <pattern|re:regex> <root_dir> <ext> <flags>")
@@ -20,7 +20,7 @@ func ParseArgs() (pattern []*regexp.Regexp, root string, extList []string, outpu
 		fmt.Println(PrintError(err.Error(), "valid output file argument"))
 		os.Exit(1)
 	}
-	var s []*regexp.Regexp
+
 	patternsArg := os.Args[1]
 	patternList := strings.SplitSeq(patternsArg, ",")
 	for patternsArg := range patternList {
@@ -38,14 +38,14 @@ func ParseArgs() (pattern []*regexp.Regexp, root string, extList []string, outpu
 				fmt.Println(PrintError(err.Error(), "valid regex"))
 				os.Exit(1)
 			}
-			s = append(s, re)
+			patterns = append(patterns, re)
 		} else {
 			// Literal search
 			literal := regexp.QuoteMeta(patternsArg)
 			if !case_sensitive {
 				literal = "(?i)" + literal
 			}
-			s = append(s, regexp.MustCompile(literal))
+			patterns = append(patterns, regexp.MustCompile(literal))
 		}
 	}
 
@@ -69,5 +69,5 @@ func ParseArgs() (pattern []*regexp.Regexp, root string, extList []string, outpu
 	}
 
 	/// E.g., Pattern: TODO, root: /home/monky/go, ext: .go
-	return s, root, extList, outputFile
+	return patterns, root, extList, outputFile
 }

--- a/main.go
+++ b/main.go
@@ -20,19 +20,18 @@ var (
 
 func main() {
 	fmt.Println("ccheck 2.1.0")
-	pattern, root, extList, outputFile := handling.ParseArgs()
+	patterns, root, extList, outputFile := handling.ParseArgs()
 
+	// Start timer
 	startTime := time.Now()
 
 	var wg sync.WaitGroup
 	var outputWg sync.WaitGroup
 
-	// Use outputWg to track the file output goroutine
-	outputWg.Add(1)
-	go func() {
-		defer outputWg.Done()
+	// Start a goroutine to handle output
+	outputWg.Go(func() {
 		handling.OutputToFile(outputFile, results)
-	}()
+	})
 
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -88,7 +87,7 @@ func main() {
 
 			for scanner.Scan() {
 				line := scanner.Text()
-				for _, p := range pattern {
+				for _, p := range patterns {
 					if p.MatchString(line) {
 						message := fmt.Sprintf("%s:%d: %s\n", path, lineNum, line)
 						results <- message

--- a/main.go
+++ b/main.go
@@ -88,10 +88,13 @@ func main() {
 
 			for scanner.Scan() {
 				line := scanner.Text()
-				if pattern.MatchString(line) {
-					message := fmt.Sprintf("%s:%d: %s\n", path, lineNum, line)
-					results <- message
-					resultsLen++
+				for _, p := range pattern {
+					if p.MatchString(line) {
+						message := fmt.Sprintf("%s:%d: %s\n", path, lineNum, line)
+						results <- message
+						resultsLen++
+						break // No need to check other patterns if one matches
+					}
 				}
 				lineNum++
 			}


### PR DESCRIPTION
This pull request enhances the pattern-matching capabilities of `ccheck` by allowing users to specify multiple patterns (including both literal and regex patterns) and multiple file extensions via the command line. The argument parsing logic and main processing loop have been updated to support these features. The README has also been updated to document the new syntax.

**Command-line pattern and extension improvements:**

* Updated `README.md` to document that `<pattern>` can now be a comma-separated list of patterns (with optional `re:` prefix for regex), and `<file_extension>` can also be a comma-separated list for multiple extensions.
* Modified `ParseArgs` in `handling/args.go` to accept and process multiple patterns, supporting both literal and regex patterns, and to handle multiple file extensions. [[1]](diffhunk://#diff-1a98e58779f1b8859eb800245755e152cbbaefd333725ebccde26b2c70dae66bL10-R10) [[2]](diffhunk://#diff-1a98e58779f1b8859eb800245755e152cbbaefd333725ebccde26b2c70dae66bL23-R32) [[3]](diffhunk://#diff-1a98e58779f1b8859eb800245755e152cbbaefd333725ebccde26b2c70dae66bL36-R49)

**Main processing logic:**

* Updated `main.go` to iterate over all provided patterns when checking each line, stopping at the first match per line.

**Code structure and concurrency:**

* Refactored output goroutine handling in `main.go` to use a more idiomatic approach for managing goroutines.